### PR TITLE
Renamed a utility routine tensor_cvt_copy_KCRSck_vnni2_to_norm_f32 to match it non-vnni2-specific behavior

### DIFF
--- a/include/dnn_common.h
+++ b/include/dnn_common.h
@@ -1703,7 +1703,7 @@ LIBXSMM_INLINE void tensor_copy_KCRSck_to_KCRS(float *src, float *dst, int K, in
   }
 }
 
-LIBXSMM_INLINE void tensor_cvt_copy_KCRSck_vnni2_to_norm_f32(libxsmm_bfloat16 *src, float *dst, int K, int C, int R, int S, int bc, int bk)
+LIBXSMM_INLINE void tensor_cvt_copy_KCRSck_vnni_to_norm_f32(libxsmm_bfloat16 *src, float *dst, int K, int C, int R, int S, int bc, int bk)
 {
   int k1, k2, c1, c2, r, s;
   int cBlocks = C/bc;

--- a/tests/conv/layer_example.c
+++ b/tests/conv/layer_example.c
@@ -619,7 +619,7 @@ int main(int argc, char* argv[])
       }
     }
     if (prec == 2) {
-      tensor_cvt_copy_KCRSck_vnni2_to_norm_f32( dfilter_libxsmm_bf16, dfilter_libxsmm, nOfm, nIfm, kh, kw, libxsmm_dnn_conv_cfg.ifmblock, libxsmm_dnn_conv_cfg.ofmblock );
+      tensor_cvt_copy_KCRSck_vnni_to_norm_f32( dfilter_libxsmm_bf16, dfilter_libxsmm, nOfm, nIfm, kh, kw, libxsmm_dnn_conv_cfg.ifmblock, libxsmm_dnn_conv_cfg.ofmblock );
       libxsmm_rne_convert_fp32_bf16( naive_filter_wu, naive_filter_wu_bf16, nOfm*nIfm*kh*kw );
       libxsmm_convert_bf16_f32( naive_filter_wu_bf16, naive_filter_wu, nOfm*nIfm*kh*kw );
     } else if (prec == 1) {


### PR DESCRIPTION
Rationale: since the routine uses vnni blocking factor returned by the libxsmm utility function, it's not vnni2 specific.

Existing name would be confusing if used for non x86 architectures (say, GVT3 with VNNI4)