### PR TITLE
Restricted fusion to bias for the new fc resnet-50 layer in the test

### DIFF
--- a/tests/fc/layer_example.c
+++ b/tests/fc/layer_example.c
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
   int nImg = 256;          /* mini-batch size, "N" */
   int nIFm = 1024;          /* number of input feature maps, "C" */
   int nOFm = 1024;          /* number of output feature maps, "K" */
-  int fuse_type = 0;      /* 0: nothing fused, 1: relu fused, 2: elementwise fused, 4: relu and elementwise fused, 6: relu fused with mask, 7: relu with mask and elementwise fused */
+  int fuse_type = 0;      /* 0: nothing fused, 1: elementwise fused, 2: relu fused, 3: relu and elementwise fused, 4: relu fused with mask, 5: relu with mask and elementwise fused */
   char type = 'A';        /* 'A': ALL, 'F': FP, 'B': BP, 'U', WU */
   int bn = 32;
   int bk = 32;
@@ -162,7 +162,7 @@ int main(int argc, char* argv[])
     return -1;
   }
   if ( (fuse_type < 0) || (fuse_type > 5) ) {
-    printf("fuse type needs to be 0 (None), 1 (Bias), 2 (ReLU,mask), 3 (Bias+ReLU,mask), 4 (ReLU), 5 (Bias+ReLU)\n");
+    printf("fuse type needs to be 0 (None), 1 (Bias), 2 (ReLU), 3 (Bias+ReLU), 4 (ReLU, mask), 5 (Bias+ReLU, mask)\n");
     return -1;
   }
 

--- a/tests/fc/run_fullyconnected.sh
+++ b/tests/fc/run_fullyconnected.sh
@@ -111,7 +111,7 @@ ${NUMACTL} "${HERE}/layer_example" ${ITERS} ${MB} 512 1024 ${FUSE} ${TYPE} ${BN}
 ${NUMACTL} "${HERE}/layer_example" ${ITERS} ${MB} 1024 1024 ${FUSE} ${TYPE} ${BN} ${BK} ${BC} ${PREC}
 ${NUMACTL} "${HERE}/layer_example" ${ITERS} ${MB} 2048 512 ${FUSE} ${TYPE} ${BN} ${BK} ${BC} ${PREC}
 
-# ResNet-50 fc layer
-${NUMACTL} "${HERE}/layer_example" ${ITERS} ${MB} 2048 1000 ${FUSE} ${TYPE} ${BN} ${BK} ${BC} ${PREC}
+# ResNet-50 fc layer with bias fusion
+${NUMACTL} "${HERE}/layer_example" ${ITERS} ${MB} 2048 1000 1 ${TYPE} ${BN} ${BK} ${BC} ${PREC}
 
 "${HERE}/../performance.sh"


### PR DESCRIPTION
Other types of fusion do not work with K=1000 (say, relu + mask). Helping CI thus.