### PR TITLE
Switched to BCAST_COL_IN_0 for bias in conv fwd (as a more performant version potentially)

### DIFF
--- a/src/libxsmm_dnn_conv.c
+++ b/src/libxsmm_dnn_conv.c
@@ -1436,7 +1436,7 @@ LIBXSMM_API_INLINE void libxsmm_dnn_conv_generate_fwd_kernels( libxsmm_dnn_conv_
       binary_shape.ldi       = stride_in;
       binary_shape.ldi2      = stride_in;
       binary_shape.ldo       = stride_out;
-      res.colbias_add_kernel_f32 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1) ;
+      res.colbias_add_kernel_f32 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0) ;
       if (  res.colbias_add_kernel_f32  == NULL ) {
         fprintf( stderr, "JIT for TPP colbias_add_kernel_f32 failed. Bailing...!\n");
         exit(-1);
@@ -1736,7 +1736,7 @@ LIBXSMM_API_INLINE void libxsmm_dnn_conv_generate_fwd_kernels( libxsmm_dnn_conv_
       binary_shape.ldi       = stride_in;
       binary_shape.ldi2      = stride_in;
       binary_shape.ldo       = stride_out;
-      res.colbias_add_kernel_bf16 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1) ;
+      res.colbias_add_kernel_bf16 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0) ;
       if (  res.colbias_add_kernel_bf16  == NULL ) {
         fprintf( stderr, "JIT for TPP colbias_add_kernel_bf16 failed. Bailing...!\n");
         exit(-1);
@@ -2034,7 +2034,7 @@ LIBXSMM_API_INLINE void libxsmm_dnn_conv_generate_fwd_kernels( libxsmm_dnn_conv_
       binary_shape.ldi       = stride_in;
       binary_shape.ldi2      = stride_in;
       binary_shape.ldo       = stride_out;
-      res.colbias_add_kernel_bf8 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1) ;
+      res.colbias_add_kernel_bf8 = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0) ;
       if (  res.colbias_add_kernel_bf8  == NULL ) {
         fprintf( stderr, "JIT for TPP colbias_add_kernel_bf8 failed. Bailing...!\n");
         exit(-1);

--- a/src/libxsmm_dnn_conv_fwd_custom_custom_bf16.c
+++ b/src/libxsmm_dnn_conv_fwd_custom_custom_bf16.c
@@ -216,8 +216,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec_bf16( libxsmm_dnn_conv_config cfg, co
                     if ( (kj == cfg.R-1) && (ki == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                       /* Apply b2b kernels */
                       if (fuse_colbias) {
-                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         cfg.colbias_add_kernel_bf16( &binary_param );
                       }
@@ -358,8 +358,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec_bf16( libxsmm_dnn_conv_config cfg, co
                               if ( (kj1 == cfg.R-1) && (ki1 == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                                 /* Apply b2b kernels */
                                 if (fuse_colbias) {
-                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   cfg.colbias_add_kernel_bf16( &binary_param );
                                 }

--- a/src/libxsmm_dnn_conv_fwd_custom_custom_bf8.c
+++ b/src/libxsmm_dnn_conv_fwd_custom_custom_bf8.c
@@ -216,8 +216,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec_bf8( libxsmm_dnn_conv_config cfg, con
                     if ( (kj == cfg.R-1) && (ki == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                       /* Apply b2b kernels */
                       if (fuse_colbias) {
-                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         cfg.colbias_add_kernel_bf8( &binary_param );
                       }
@@ -358,8 +358,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec_bf8( libxsmm_dnn_conv_config cfg, con
                               if ( (kj1 == cfg.R-1) && (ki1 == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                                 /* Apply b2b kernels */
                                 if (fuse_colbias) {
-                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   cfg.colbias_add_kernel_bf8( &binary_param );
                                 }

--- a/src/libxsmm_dnn_conv_fwd_custom_custom_f32.c
+++ b/src/libxsmm_dnn_conv_fwd_custom_custom_f32.c
@@ -208,8 +208,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec( libxsmm_dnn_conv_config cfg, const f
                     if ( (kj == cfg.R-1) && (ki == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                       /* Apply b2b kernels */
                       if (fuse_colbias) {
-                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                        binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                         cfg.colbias_add_kernel_f32( &binary_param );
                       }
@@ -344,8 +344,8 @@ LIBXSMM_API void libxsmm_dnn_conv_fwd_exec( libxsmm_dnn_conv_config cfg, const f
                               if ( (kj1 == cfg.R-1) && (ki1 == cfg.S-1) && (ifm1 + cfg.blocksifm_blocking >= cfg.blocksifm) ) {
                                 /* Apply b2b kernels */
                                 if (fuse_colbias) {
-                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
-                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in0.primary = (void*)&LIBXSMM_VLA_ACCESS(2, colbias, ofm1, 0, cfg.ofmblock);
+                                  binary_param.in1.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   binary_param.out.primary = (void*)&LIBXSMM_VLA_ACCESS(5, output, img, ofm1, oj_use, oi_use, 0, cfg.blocksofm, cfg.ofhp, cfg.ofwp, cfg.ofmblock);
                                   cfg.colbias_add_kernel_f32( &binary_param );
                                 }


### PR DESCRIPTION
Rationale: better code will be generated (even if no real performance gains on checked convolution configs).

Tested with adding into run_convs.sh
PREC=4
ITERS=1
FUSE=1
"${HERE}/layer_example" ${ITERS} 7 7 ${MB} 64 64 3 3 1 1 1 ${TYPE} L ${PAD} ${FUSE} ${BC} ${BK} ${PREC} # whatever are default parameters in run_convs.sh for the rest